### PR TITLE
Allow IMN without sell price and enhance branch inventory

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -82,6 +82,14 @@ def ensure_schema_patches():
         conn.exec_driver_sql("CREATE INDEX IF NOT EXISTS idx_med_category_id ON public.medicines(category_id);")
         conn.exec_driver_sql("CREATE INDEX IF NOT EXISTS idx_dev_category_id ON public.medical_devices(category_id);")
 
+        # ensure medical_devices.sell_price has default 0
+        dev_cols_info = insp.get_columns("medical_devices")
+        sell_col = next((c for c in dev_cols_info if c["name"] == "sell_price"), None)
+        if sell_col and sell_col.get("default") is None:
+            conn.exec_driver_sql(
+                "ALTER TABLE public.medical_devices ALTER COLUMN sell_price SET DEFAULT 0"
+            )
+
         # --- 2) DML: backfill using SQLAlchemy Core (no raw placeholders) ---
 
         md = MetaData()
@@ -388,12 +396,13 @@ async def create_medical_device(device: MedicalDeviceCreate, db: Session = Depen
         raise HTTPException(status_code=400, detail="Invalid category for medical device")
 
     device_id = str(uuid.uuid4())
+    sell_price = device.sell_price if device.sell_price is not None else 0
     db_device = DBMedicalDevice(
         id=device_id,
         name=device.name,
         category_id=device.category_id,
         purchase_price=device.purchase_price,
-        sell_price=device.sell_price,
+        sell_price=sell_price,
         quantity=device.quantity,
         branch_id=device.branch_id,
     )
@@ -416,6 +425,8 @@ async def update_medical_device(device_id: str, device: MedicalDeviceUpdate, db:
         raise HTTPException(status_code=400, detail="Invalid category for medical device")
 
     for field, value in device.model_dump(exclude_unset=True).items():
+        if field == "sell_price" and value is None:
+            continue
         setattr(db_device, field, value)
 
     db.commit()
@@ -890,6 +901,45 @@ async def mark_notification_read(notification_id: str, db: Session = Depends(get
     db.commit()
     return {"message": "Notification marked as read"}
 
+# Last receipt endpoints
+@app.get("/branches/{branch_id}/items/medicine/{medicine_id}/last_receipt")
+async def get_last_medicine_receipt(branch_id: str, medicine_id: str, db: Session = Depends(get_db)):
+    result = (
+        db.query(DBShipmentItem, DBShipment)
+        .join(DBShipment, DBShipmentItem.shipment_id == DBShipment.id)
+        .filter(
+            DBShipment.to_branch_id == branch_id,
+            DBShipment.status == "accepted",
+            DBShipmentItem.item_type == "medicine",
+            DBShipmentItem.item_id == medicine_id,
+        )
+        .order_by(DBShipment.created_at.desc())
+        .first()
+    )
+    if result:
+        item, shipment = result
+        return {"quantity": item.quantity, "time": shipment.created_at}
+    return None
+
+@app.get("/branches/{branch_id}/items/device/{device_id}/last_receipt")
+async def get_last_device_receipt(branch_id: str, device_id: str, db: Session = Depends(get_db)):
+    result = (
+        db.query(DBShipmentItem, DBShipment)
+        .join(DBShipment, DBShipmentItem.shipment_id == DBShipment.id)
+        .filter(
+            DBShipment.to_branch_id == branch_id,
+            DBShipment.status == "accepted",
+            DBShipmentItem.item_type == "medical_device",
+            DBShipmentItem.item_id == device_id,
+        )
+        .order_by(DBShipment.created_at.desc())
+        .first()
+    )
+    if result:
+        item, shipment = result
+        return {"quantity": item.quantity, "time": shipment.created_at}
+    return None
+
 # Dispensing endpoints
 @app.get("/dispensing_records")
 async def get_dispensing_records(branch_id: Optional[str] = None, db: Session = Depends(get_db)):
@@ -1022,13 +1072,14 @@ async def create_arrivals(batch: BatchArrivalCreate, db: Session = Depends(get_d
     try:
         for arrival_data in batch.arrivals:
             # Create arrival record
+            sell_price = arrival_data.sell_price if arrival_data.sell_price is not None else 0
             db_arrival = DBArrival(
                 id=str(uuid.uuid4()),
                 medicine_id=arrival_data.medicine_id,
                 medicine_name=arrival_data.medicine_name,
                 quantity=arrival_data.quantity,
                 purchase_price=arrival_data.purchase_price,
-                sell_price=arrival_data.sell_price
+                sell_price=sell_price
             )
             db.add(db_arrival)
             
@@ -1041,7 +1092,8 @@ async def create_arrivals(batch: BatchArrivalCreate, db: Session = Depends(get_d
             if medicine:
                 medicine.quantity += arrival_data.quantity
                 medicine.purchase_price = arrival_data.purchase_price
-                medicine.sell_price = arrival_data.sell_price
+                if arrival_data.sell_price is not None:
+                    medicine.sell_price = arrival_data.sell_price
         
         db.commit()
         return {"message": "Arrivals created successfully"}
@@ -1060,13 +1112,14 @@ async def get_device_arrivals(db: Session = Depends(get_db)):
 async def create_device_arrivals(batch: BatchDeviceArrivalCreate, db: Session = Depends(get_db)):
     try:
         for arrival_data in batch.arrivals:
+            sell_price = arrival_data.sell_price if arrival_data.sell_price is not None else 0
             db_arrival = DBDeviceArrival(
                 id=str(uuid.uuid4()),
                 device_id=arrival_data.device_id,
                 device_name=arrival_data.device_name,
                 quantity=arrival_data.quantity,
                 purchase_price=arrival_data.purchase_price,
-                sell_price=arrival_data.sell_price,
+                sell_price=sell_price,
             )
             db.add(db_arrival)
 
@@ -1077,7 +1130,8 @@ async def create_device_arrivals(batch: BatchDeviceArrivalCreate, db: Session = 
             if device:
                 device.quantity += arrival_data.quantity
                 device.purchase_price = arrival_data.purchase_price
-                device.sell_price = arrival_data.sell_price
+                if arrival_data.sell_price is not None:
+                    device.sell_price = arrival_data.sell_price
 
         db.commit()
         return {"message": "Device arrivals created successfully"}

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -167,7 +167,7 @@ class ArrivalBase(BaseModel):
     medicine_name: str
     quantity: int
     purchase_price: float
-    sell_price: float
+    sell_price: Optional[float] = None
 
 class ArrivalCreate(ArrivalBase):
     pass
@@ -195,7 +195,7 @@ class DeviceArrivalBase(BaseModel):
     device_name: str
     quantity: int
     purchase_price: float
-    sell_price: float
+    sell_price: Optional[float] = None
 
 
 class DeviceArrivalCreate(DeviceArrivalBase):
@@ -234,7 +234,7 @@ class MedicalDeviceBase(BaseModel):
     name: str
     category_id: str
     purchase_price: float
-    sell_price: float
+    sell_price: Optional[float] = None
     quantity: int
     branch_id: Optional[str] = None
 

--- a/src/components/number-input.tsx
+++ b/src/components/number-input.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+
+interface NumberInputProps extends React.ComponentProps<typeof Input> {
+  value: string;
+  onValueChange: (value: string) => void;
+  allowDecimal?: boolean;
+}
+
+const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
+  ({ value, onValueChange, allowDecimal = false, onFocus, onBlur, onChange, ...props }, ref) => {
+    const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (value === '0') {
+        onValueChange('');
+        requestAnimationFrame(() => e.currentTarget.select());
+      }
+      onFocus?.(e);
+    };
+
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (value === '') {
+        onValueChange('0');
+      }
+      onBlur?.(e);
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value;
+      const regex = allowDecimal ? /^\d*(?:[\.\,]?\d*)?$/ : /^\d*$/;
+      if (regex.test(val)) {
+        onValueChange(val.replace(',', '.'));
+      }
+      onChange?.(e);
+    };
+
+    return (
+      <Input
+        {...props}
+        ref={ref}
+        value={value}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        placeholder="0"
+        inputMode={allowDecimal ? 'decimal' : 'numeric'}
+        min={0}
+      />
+    );
+  }
+);
+NumberInput.displayName = 'NumberInput';
+
+export default NumberInput;

--- a/src/pages/admin/Arrivals.tsx
+++ b/src/pages/admin/Arrivals.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import NumberInput from '@/components/number-input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -10,9 +10,8 @@ import { Plus, Trash2, Save } from 'lucide-react';
 
 interface ArrivalItem {
   itemId: string;
-  quantity: number;
-  purchasePrice: number;
-  sellPrice: number;
+  quantity: string;
+  purchasePrice: string;
 }
 
 const AdminArrivals: React.FC = () => {
@@ -43,7 +42,7 @@ const AdminArrivals: React.FC = () => {
   };
 
   const addArrival = (type: 'medicine' | 'device') => {
-    const item = { itemId: '', quantity: 1, purchasePrice: 0, sellPrice: 0 };
+    const item = { itemId: '', quantity: '0', purchasePrice: '0' };
     type === 'medicine'
       ? setMedicineArrivals([...medicineArrivals, item])
       : setDeviceArrivals([...deviceArrivals, item]);
@@ -56,7 +55,7 @@ const AdminArrivals: React.FC = () => {
     value: string | number,
   ) => {
     const list = type === 'medicine' ? [...medicineArrivals] : [...deviceArrivals];
-    list[index] = { ...list[index], [field]: value };
+    (list[index] as any)[field] = value;
     type === 'medicine' ? setMedicineArrivals(list) : setDeviceArrivals(list);
   };
 
@@ -75,13 +74,11 @@ const AdminArrivals: React.FC = () => {
           [`${key}_id`]: arr.itemId,
           [`${key}_name`]: item?.name || '',
           quantity: 0,
-          purchase_price: arr.purchasePrice,
-          sell_price: arr.sellPrice,
+          purchase_price: parseFloat(arr.purchasePrice),
         };
       }
-      grouped[arr.itemId].quantity += arr.quantity;
-      grouped[arr.itemId].purchase_price = arr.purchasePrice;
-      grouped[arr.itemId].sell_price = arr.sellPrice;
+      grouped[arr.itemId].quantity += parseInt(arr.quantity);
+      grouped[arr.itemId].purchase_price = parseFloat(arr.purchasePrice);
     }
     return Object.values(grouped);
   };
@@ -162,15 +159,11 @@ const AdminArrivals: React.FC = () => {
                 </div>
                 <div>
                   <Label>Количество</Label>
-                  <Input type="number" value={arrival.quantity} onChange={(e) => updateArrival('medicine', index, 'quantity', Number(e.target.value))} />
+                  <NumberInput value={arrival.quantity} onValueChange={(v) => updateArrival('medicine', index, 'quantity', v)} />
                 </div>
                 <div>
                   <Label>Цена закупки</Label>
-                  <Input type="number" value={arrival.purchasePrice} onChange={(e) => updateArrival('medicine', index, 'purchasePrice', Number(e.target.value))} />
-                </div>
-                <div>
-                  <Label>Цена продажи</Label>
-                  <Input type="number" value={arrival.sellPrice} onChange={(e) => updateArrival('medicine', index, 'sellPrice', Number(e.target.value))} />
+                  <NumberInput allowDecimal value={arrival.purchasePrice} onValueChange={(v) => updateArrival('medicine', index, 'purchasePrice', v)} />
                 </div>
                 <div className="flex items-end">
                   <Button variant="destructive" onClick={() => removeArrival('medicine', index)}>
@@ -212,15 +205,11 @@ const AdminArrivals: React.FC = () => {
                 </div>
                 <div>
                   <Label>Количество</Label>
-                  <Input type="number" value={arrival.quantity} onChange={(e) => updateArrival('device', index, 'quantity', Number(e.target.value))} />
+                  <NumberInput value={arrival.quantity} onValueChange={(v) => updateArrival('device', index, 'quantity', v)} />
                 </div>
                 <div>
                   <Label>Цена закупки</Label>
-                  <Input type="number" value={arrival.purchasePrice} onChange={(e) => updateArrival('device', index, 'purchasePrice', Number(e.target.value))} />
-                </div>
-                <div>
-                  <Label>Цена продажи</Label>
-                  <Input type="number" value={arrival.sellPrice} onChange={(e) => updateArrival('device', index, 'sellPrice', Number(e.target.value))} />
+                  <NumberInput allowDecimal value={arrival.purchasePrice} onValueChange={(v) => updateArrival('device', index, 'purchasePrice', v)} />
                 </div>
                 <div className="flex items-end">
                   <Button variant="destructive" onClick={() => removeArrival('device', index)}>

--- a/src/pages/admin/MedicalDevices.tsx
+++ b/src/pages/admin/MedicalDevices.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import NumberInput from '@/components/number-input';
 import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -18,9 +19,8 @@ const AdminMedicalDevices: React.FC = () => {
   const [formData, setFormData] = useState({
     name: '',
     categoryId: '',
-    purchasePrice: '',
-    sellPrice: '',
-    quantity: '',
+    purchasePrice: '0',
+    quantity: '0',
     branchId: '',
   });
 
@@ -44,12 +44,12 @@ const AdminMedicalDevices: React.FC = () => {
   };
 
   const resetForm = () => {
-    setFormData({ name: '', categoryId: '', purchasePrice: '', sellPrice: '', quantity: '', branchId: '' });
+    setFormData({ name: '', categoryId: '', purchasePrice: '0', quantity: '0', branchId: '' });
     setEditingDevice(null);
   };
 
   const handleSubmit = async () => {
-    if (!formData.name || !formData.categoryId || !formData.purchasePrice || !formData.sellPrice || !formData.quantity) {
+    if (!formData.name || !formData.categoryId || !formData.purchasePrice || !formData.quantity) {
       toast({ title: 'Ошибка', description: 'Заполните все поля', variant: 'destructive' });
       return;
     }
@@ -58,7 +58,6 @@ const AdminMedicalDevices: React.FC = () => {
       name: formData.name,
       category_id: formData.categoryId,
       purchase_price: parseFloat(formData.purchasePrice),
-      sell_price: parseFloat(formData.sellPrice),
       quantity: parseInt(formData.quantity),
       branch_id: formData.branchId || null,
     };
@@ -67,7 +66,7 @@ const AdminMedicalDevices: React.FC = () => {
       if (editingDevice) {
         const res = await apiService.updateMedicalDevice(editingDevice.id, payload);
         if (!res.error) {
-          setDevices((prev) => prev.map((d) => (d.id === editingDevice.id ? { ...payload, id: editingDevice.id } : d)));
+          setDevices((prev) => prev.map((d) => (d.id === editingDevice.id ? { ...d, ...payload, id: editingDevice.id } : d)));
           toast({ title: 'ИМН обновлено' });
         } else {
           toast({ title: 'Ошибка', description: res.error, variant: 'destructive' });
@@ -96,7 +95,6 @@ const AdminMedicalDevices: React.FC = () => {
       name: device.name,
       categoryId: device.category_id,
       purchasePrice: device.purchase_price.toString(),
-      sellPrice: device.sell_price.toString(),
       quantity: device.quantity.toString(),
       branchId: device.branch_id || '',
     });
@@ -155,15 +153,11 @@ const AdminMedicalDevices: React.FC = () => {
               </div>
               <div>
                 <Label>Цена закупки</Label>
-                <Input type="number" value={formData.purchasePrice} onChange={(e) => setFormData({ ...formData, purchasePrice: e.target.value })} />
-              </div>
-              <div>
-                <Label>Цена продажи</Label>
-                <Input type="number" value={formData.sellPrice} onChange={(e) => setFormData({ ...formData, sellPrice: e.target.value })} />
+                <NumberInput allowDecimal value={formData.purchasePrice} onValueChange={(v) => setFormData({ ...formData, purchasePrice: v })} />
               </div>
               <div>
                 <Label>Количество</Label>
-                <Input type="number" value={formData.quantity} onChange={(e) => setFormData({ ...formData, quantity: e.target.value })} />
+                <NumberInput value={formData.quantity} onValueChange={(v) => setFormData({ ...formData, quantity: v })} />
               </div>
               <div>
                 <Label>ID филиала (опционально)</Label>

--- a/src/pages/admin/Medicines.tsx
+++ b/src/pages/admin/Medicines.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import NumberInput from '@/components/number-input';
 import { Label } from '@/components/ui/label';
 import {
   Dialog,
@@ -23,8 +24,8 @@ const Medicines: React.FC = () => {
   
   const [formData, setFormData] = useState({
     name: '',
-    purchasePrice: '',
-    quantity: '',
+    purchasePrice: '0',
+    quantity: '0',
     categoryId: ''
   });
 
@@ -58,8 +59,8 @@ const Medicines: React.FC = () => {
   const resetForm = () => {
     setFormData({
       name: '',
-      purchasePrice: '',
-      quantity: '',
+      purchasePrice: '0',
+      quantity: '0',
       categoryId: ''
     });
     setEditingMedicine(null);
@@ -178,20 +179,19 @@ const Medicines: React.FC = () => {
               </div>
               <div>
                 <Label htmlFor="purchasePrice">Цена закупки (₸)</Label>
-                <Input
+                <NumberInput
                   id="purchasePrice"
-                  type="number"
+                  allowDecimal
                   value={formData.purchasePrice}
-                  onChange={(e) => setFormData({ ...formData, purchasePrice: e.target.value })}
+                  onValueChange={(v) => setFormData({ ...formData, purchasePrice: v })}
                 />
               </div>
               <div>
                 <Label htmlFor="quantity">Количество</Label>
-                <Input
+                <NumberInput
                   id="quantity"
-                  type="number"
                   value={formData.quantity}
-                  onChange={(e) => setFormData({ ...formData, quantity: e.target.value })}
+                  onValueChange={(v) => setFormData({ ...formData, quantity: v })}
                 />
               </div>
               <div>

--- a/src/pages/branch/BranchDashboard.tsx
+++ b/src/pages/branch/BranchDashboard.tsx
@@ -3,16 +3,21 @@ import React, { useState, useEffect } from 'react';
 import { storage } from '@/utils/storage';
 import { apiService } from '@/utils/api';
 import { Package, Users, UserCheck, ArrowLeftRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 
 const BranchDashboard: React.FC = () => {
   const currentUser = storage.getCurrentUser();
   const branchId = currentUser?.branchId;
   
   const [medicines, setMedicines] = useState<any[]>([]);
+  const [devices, setDevices] = useState<any[]>([]);
   const [employees, setEmployees] = useState<any[]>([]);
   const [patients, setPatients] = useState<any[]>([]);
   const [dispensings, setDispensings] = useState<any[]>([]);
+  const [shipments, setShipments] = useState<any[]>([]);
+  const [notifications, setNotifications] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchData();
@@ -20,17 +25,23 @@ const BranchDashboard: React.FC = () => {
 
   const fetchData = async () => {
     try {
-      const [medicinesRes, employeesRes, patientsRes, dispensingsRes] = await Promise.all([
+      const [medicinesRes, devicesRes, employeesRes, patientsRes, dispensingsRes, shipmentsRes, notificationsRes] = await Promise.all([
         apiService.getMedicines(branchId),
+        apiService.getMedicalDevices(branchId),
         apiService.getEmployees(branchId),
         apiService.getPatients(branchId),
-        apiService.getDispensings(branchId)
+        apiService.getDispensings(branchId),
+        apiService.getShipments(branchId),
+        apiService.getNotifications(branchId)
       ]);
 
       if (medicinesRes.data) setMedicines(medicinesRes.data);
+      if (devicesRes.data) setDevices(devicesRes.data);
       if (employeesRes.data) setEmployees(employeesRes.data);
       if (patientsRes.data) setPatients(patientsRes.data);
       if (dispensingsRes.data) setDispensings(dispensingsRes.data);
+      if (shipmentsRes.data) setShipments(shipmentsRes.data);
+      if (notificationsRes.data) setNotifications(notificationsRes.data);
     } catch (error) {
       console.error('Error fetching branch data:', error);
     } finally {
@@ -43,7 +54,10 @@ const BranchDashboard: React.FC = () => {
   }
 
   const totalMedicines = medicines.reduce((sum, med) => sum + med.quantity, 0);
+  const totalDevices = devices.reduce((sum, dev) => sum + dev.quantity, 0);
   const totalDispensed = dispensings.reduce((sum, disp) => sum + disp.quantity, 0);
+  const hasPendingShipments = shipments.some((s) => s.status === 'pending');
+  const hasUnreadNotifications = notifications.some((n: any) => !n.is_read);
 
   const stats = [
     {
@@ -51,6 +65,12 @@ const BranchDashboard: React.FC = () => {
       value: totalMedicines,
       icon: Package,
       color: 'bg-blue-500'
+    },
+    {
+      title: 'ИМН в наличии',
+      value: totalDevices,
+      icon: Package,
+      color: 'bg-teal-500'
     },
     {
       title: 'Сотрудники',
@@ -74,10 +94,21 @@ const BranchDashboard: React.FC = () => {
 
   return (
     <div>
-      <div className="mb-8">
+      <div className="mb-4">
         <h1 className="text-3xl font-bold text-gray-900">{currentUser?.branchName}</h1>
         <p className="text-gray-600 mt-2">Панель управления филиалом</p>
       </div>
+
+      {(hasPendingShipments || hasUnreadNotifications) && (
+        <div
+          className="mb-8 p-4 bg-yellow-100 text-yellow-800 rounded cursor-pointer"
+          onClick={() => navigate(hasPendingShipments ? '/branch/arrivals' : '/branch/notifications')}
+        >
+          {hasPendingShipments
+            ? 'Есть ожидающие поступления'
+            : 'Есть непрочитанные уведомления'}
+        </div>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         {stats.map((stat, index) => {

--- a/src/pages/branch/MedicalDevices.tsx
+++ b/src/pages/branch/MedicalDevices.tsx
@@ -5,6 +5,7 @@ import { Package, Search } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 
 const BranchMedicalDevices: React.FC = () => {
   const currentUser = storage.getCurrentUser();
@@ -14,6 +15,8 @@ const BranchMedicalDevices: React.FC = () => {
   const [categories, setCategories] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
+  const [receiptInfo, setReceiptInfo] = useState<any>(null);
+  const [receiptOpen, setReceiptOpen] = useState(false);
 
   useEffect(() => {
     fetchData();
@@ -45,6 +48,12 @@ const BranchMedicalDevices: React.FC = () => {
     getCategoryName(device.category_id).toLowerCase().includes(searchTerm.toLowerCase())
   );
 
+  const handleCardClick = async (device: any) => {
+    const res = await apiService.getLastReceiptDevice(branchId, device.id);
+    setReceiptInfo(res.data || null);
+    setReceiptOpen(true);
+  };
+
   if (loading) {
     return <div className="flex justify-center items-center h-64">Загрузка ИМН...</div>;
   }
@@ -68,23 +77,17 @@ const BranchMedicalDevices: React.FC = () => {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {filteredDevices.map((device) => (
-          <Card key={device.id}>
+          <Card key={device.id} onClick={() => handleCardClick(device)} className="cursor-pointer">
             <CardHeader className="pb-3">
               <CardTitle className="text-lg">{device.name}</CardTitle>
               <Badge variant="secondary">{getCategoryName(device.category_id)}</Badge>
             </CardHeader>
             <CardContent>
-              <div className="space-y-2">
-                <div className="flex justify-between">
-                  <span className="text-sm text-muted-foreground">Цена закупки:</span>
-                  <span className="font-medium">{device.purchase_price?.toFixed(2)} ₸</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-sm text-muted-foreground">Количество:</span>
-                  <Badge variant={device.quantity > 10 ? "default" : device.quantity > 0 ? "secondary" : "destructive"}>
-                    {device.quantity} шт.
-                  </Badge>
-                </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-muted-foreground">Количество:</span>
+                <Badge variant={device.quantity > 10 ? "default" : device.quantity > 0 ? "secondary" : "destructive"}>
+                  {device.quantity} шт.
+                </Badge>
               </div>
             </CardContent>
           </Card>
@@ -99,6 +102,20 @@ const BranchMedicalDevices: React.FC = () => {
           </p>
         </div>
       )}
+      <Dialog open={receiptOpen} onOpenChange={setReceiptOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Последнее поступление</DialogTitle>
+          </DialogHeader>
+          {receiptInfo ? (
+            <p>
+              Последнее поступление: {receiptInfo.quantity} шт • {new Date(receiptInfo.time).toLocaleString()}
+            </p>
+          ) : (
+            <p>Поступлений не было</p>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/src/pages/branch/Medicines.tsx
+++ b/src/pages/branch/Medicines.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import NumberInput from '@/components/number-input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -21,14 +22,16 @@ const BranchMedicines: React.FC = () => {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [editingMedicine, setEditingMedicine] = useState<any>(null);
+  const [receiptInfo, setReceiptInfo] = useState<any>(null);
+  const [receiptOpen, setReceiptOpen] = useState(false);
 
   // Form state
   const [formData, setFormData] = useState({
     name: '',
     category_id: '',
-    purchase_price: 0,
-    sell_price: 0,
-    quantity: 0
+    purchase_price: '0',
+    sell_price: '0',
+    quantity: '0'
   });
 
   useEffect(() => {
@@ -51,6 +54,12 @@ const BranchMedicines: React.FC = () => {
     }
   };
 
+  const handleRowClick = async (medicine: any) => {
+    const res = await apiService.getLastReceiptMedicine(branchId, medicine.id);
+    setReceiptInfo(res.data || null);
+    setReceiptOpen(true);
+  };
+
   const handleCreate = async () => {
     if (!formData.name || !formData.category_id) {
       toast({ title: 'Ошибка', description: 'Заполните все обязательные поля', variant: 'destructive' });
@@ -59,7 +68,11 @@ const BranchMedicines: React.FC = () => {
 
     try {
       const medicineData = {
-        ...formData,
+        name: formData.name,
+        category_id: formData.category_id,
+        purchase_price: parseFloat(formData.purchase_price),
+        sell_price: parseFloat(formData.sell_price),
+        quantity: parseInt(formData.quantity),
         branch_id: branchId
       };
 
@@ -85,7 +98,14 @@ const BranchMedicines: React.FC = () => {
     }
 
     try {
-      const response = await apiService.updateMedicine(editingMedicine.id, formData);
+      const response = await apiService.updateMedicine(editingMedicine.id, {
+        name: formData.name,
+        category_id: formData.category_id,
+        purchase_price: parseFloat(formData.purchase_price),
+        sell_price: parseFloat(formData.sell_price),
+        quantity: parseInt(formData.quantity),
+        branch_id: branchId
+      });
       
       if (!response.error) {
         toast({ title: 'Лекарство обновлено!' });
@@ -122,9 +142,9 @@ const BranchMedicines: React.FC = () => {
     setFormData({
       name: '',
       category_id: '',
-      purchase_price: 0,
-      sell_price: 0,
-      quantity: 0
+      purchase_price: '0',
+      sell_price: '0',
+      quantity: '0'
     });
   };
 
@@ -133,9 +153,9 @@ const BranchMedicines: React.FC = () => {
     setFormData({
       name: medicine.name,
       category_id: medicine.category_id,
-      purchase_price: medicine.purchase_price,
-      sell_price: medicine.sell_price,
-      quantity: medicine.quantity
+      purchase_price: medicine.purchase_price.toString(),
+      sell_price: medicine.sell_price.toString(),
+      quantity: medicine.quantity.toString()
     });
     setEditDialogOpen(true);
   };
@@ -198,34 +218,17 @@ const BranchMedicines: React.FC = () => {
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <Label>Закупочная цена</Label>
-                  <Input
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    value={formData.purchase_price}
-                    onChange={(e) => setFormData({...formData, purchase_price: Number(e.target.value)})}
-                  />
+                  <NumberInput allowDecimal value={formData.purchase_price} onValueChange={(v) => setFormData({ ...formData, purchase_price: v })} />
                 </div>
                 <div>
                   <Label>Цена продажи</Label>
-                  <Input
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    value={formData.sell_price}
-                    onChange={(e) => setFormData({...formData, sell_price: Number(e.target.value)})}
-                  />
+                  <NumberInput allowDecimal value={formData.sell_price} onValueChange={(v) => setFormData({ ...formData, sell_price: v })} />
                 </div>
               </div>
 
               <div>
                 <Label>Количество</Label>
-                <Input
-                  type="number"
-                  min="0"
-                  value={formData.quantity}
-                  onChange={(e) => setFormData({...formData, quantity: Number(e.target.value)})}
-                />
+                <NumberInput value={formData.quantity} onValueChange={(v) => setFormData({ ...formData, quantity: v })} />
               </div>
               
               <Button onClick={handleCreate} className="w-full">
@@ -250,21 +253,17 @@ const BranchMedicines: React.FC = () => {
                 <TableRow>
                   <TableHead>Название</TableHead>
                   <TableHead>Категория</TableHead>
-                  <TableHead>Закупочная цена</TableHead>
-                  <TableHead>Цена продажи</TableHead>
                   <TableHead>Количество</TableHead>
                   <TableHead>Действия</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {medicines.map((medicine) => (
-                  <TableRow key={medicine.id}>
+                  <TableRow key={medicine.id} onClick={() => handleRowClick(medicine)} className="cursor-pointer">
                     <TableCell className="font-medium">{medicine.name}</TableCell>
                     <TableCell>
                       <Badge variant="outline">{getCategoryName(medicine.category_id)}</Badge>
                     </TableCell>
-                    <TableCell>{medicine.purchase_price} ₸</TableCell>
-                    <TableCell>{medicine.sell_price} ₸</TableCell>
                     <TableCell>
                       <Badge variant={medicine.quantity > 0 ? "default" : "destructive"}>
                         {medicine.quantity} шт.
@@ -272,10 +271,10 @@ const BranchMedicines: React.FC = () => {
                     </TableCell>
                     <TableCell>
                       <div className="flex space-x-2">
-                        <Button variant="outline" size="sm" onClick={() => openEditDialog(medicine)}>
+                        <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); openEditDialog(medicine); }}>
                           <Edit className="h-4 w-4" />
                         </Button>
-                        <Button variant="outline" size="sm" onClick={() => handleDelete(medicine.id)}>
+                        <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); handleDelete(medicine.id); }}>
                           <Trash2 className="h-4 w-4" />
                         </Button>
                       </div>
@@ -329,40 +328,38 @@ const BranchMedicines: React.FC = () => {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <Label>Закупочная цена</Label>
-                <Input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={formData.purchase_price}
-                  onChange={(e) => setFormData({...formData, purchase_price: Number(e.target.value)})}
-                />
+                <NumberInput allowDecimal value={formData.purchase_price} onValueChange={(v) => setFormData({ ...formData, purchase_price: v })} />
               </div>
               <div>
                 <Label>Цена продажи</Label>
-                <Input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={formData.sell_price}
-                  onChange={(e) => setFormData({...formData, sell_price: Number(e.target.value)})}
-                />
+                <NumberInput allowDecimal value={formData.sell_price} onValueChange={(v) => setFormData({ ...formData, sell_price: v })} />
               </div>
             </div>
 
             <div>
               <Label>Количество</Label>
-              <Input
-                type="number"
-                min="0"
-                value={formData.quantity}
-                onChange={(e) => setFormData({...formData, quantity: Number(e.target.value)})}
-              />
+              <NumberInput value={formData.quantity} onValueChange={(v) => setFormData({ ...formData, quantity: v })} />
             </div>
             
             <Button onClick={handleEdit} className="w-full">
               Обновить лекарство
             </Button>
           </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={receiptOpen} onOpenChange={setReceiptOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Последнее поступление</DialogTitle>
+          </DialogHeader>
+          {receiptInfo ? (
+            <p>
+              Последнее поступление: {receiptInfo.quantity} шт • {new Date(receiptInfo.time).toLocaleString()}
+            </p>
+          ) : (
+            <p>Поступлений не было</p>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -316,6 +316,15 @@ class ApiService {
     });
   }
 
+  // Last receipt
+  async getLastReceiptMedicine(branchId: string, medicineId: string) {
+    return this.request<any>(`/branches/${encodeURIComponent(branchId)}/items/medicine/${medicineId}/last_receipt`);
+  }
+
+  async getLastReceiptDevice(branchId: string, deviceId: string) {
+    return this.request<any>(`/branches/${encodeURIComponent(branchId)}/items/device/${deviceId}/last_receipt`);
+  }
+
   // Notifications
   async getNotifications(branchId: string) {
     return this.request<any[]>(`/notifications?branch_id=${branchId}`);


### PR DESCRIPTION
## Summary
- allow medical devices to omit sell price and default to 0
- support arrivals without sell price and record last receipts per branch item
- add NumberInput component and improve branch dashboard with stock banners

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b186a53e8483288d1bd344673a93ed