### PR TITLE
feat: allow configuring API base URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ npm i
 npm run dev
 ```
 
+### API configuration
+
+The frontend communicates with a backend server. During development it expects
+the backend to run on `http://localhost:8000`. For production deployments or if
+your backend runs elsewhere, create a `.env` file in the project root and set
+
+```bash
+VITE_API_BASE_URL=http://your-backend-host:8000
+```
+
+When `VITE_API_BASE_URL` is not provided the application falls back to
+`http://localhost:8000`.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,8 @@
-const API_BASE_URL = 'http://localhost:8000';
+// Allow the API base URL to be configured via environment variable so the
+// frontend can communicate with a backend running on a different host in
+// production. Fallback to the local development server if the variable is not
+// provided.
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 
 interface LoginData {
   login: string;


### PR DESCRIPTION
## Summary
- allow frontend to read API base URL from VITE_API_BASE_URL env var
- document API base URL configuration and ignore local env file

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1aad420208328ae5a3ac8dd7c7dc4