### PR TITLE
Restore stable auth and seeding

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -3,6 +3,26 @@ from pydantic import BaseModel, ConfigDict
 from typing import Optional, List
 from datetime import datetime
 
+# Auth schemas
+
+class LoginIn(BaseModel):
+    login: str
+    password: str
+
+
+class UserPublic(BaseModel):
+    id: str
+    login: str
+    role: str
+    branch_id: str | None = None
+
+
+class LoginOut(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    user: UserPublic
+
+
 # User schemas
 class UserBase(BaseModel):
     login: str
@@ -22,14 +42,6 @@ class User(UserBase):
     id: str
     
     model_config = ConfigDict(from_attributes=True)
-
-class UserLogin(BaseModel):
-    login: str
-    password: str
-
-class LoginResponse(BaseModel):
-    user: User
-    token: str
 
 # Branch schemas
 class BranchBase(BaseModel):


### PR DESCRIPTION
## Summary
- restore stable login schemas and route using JWT and hashed passwords
- add idempotent startup seeding and health endpoint
- make shipment responses backward compatible

## Testing
- `python -m py_compile backend/schemas.py backend/main.py`
- `python - <<'PY'
try:
    from passlib.context import CryptContext
    from jose import jwt
    print('imports ok')
except Exception as e:
    print('import error:', e)
PY`
- `pip install 'python-jose[cryptography]' passlib[bcrypt] >/tmp/pip.log && tail -n 20 /tmp/pip.log` *(fails: Could not find a version that satisfies the requirement python-jose[cryptography])*

------
https://chatgpt.com/codex/tasks/task_e_68b28b2b011c8328ba275f2935bf6d6c