### PR TITLE
Replace JWT with DB-backed session tokens

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,8 +6,9 @@
 1. Install PostgreSQL
 2. Create database: `warehouse_db`
 3. Update DATABASE_URL in .env file
-4. Install dependencies: `pip install -r requirements.txt`
-5. Run server: `python main.py`
+4. If you previously installed `jose`, remove it: `pip uninstall -y jose`
+5. Install dependencies: `pip install -r requirements.txt`
+6. Run server: `python main.py`
 
 ## API Endpoints
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,7 +1,7 @@
 
 from sqlalchemy import create_engine, Column, Integer, String, Float, DateTime, ForeignKey, Text, Boolean
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import sessionmaker
 from datetime import datetime
 import os
 from dotenv import load_dotenv
@@ -18,12 +18,13 @@ Base = declarative_base()
 # Database Models
 class User(Base):
     __tablename__ = "users"
-    
+
     id = Column(String, primary_key=True)
     login = Column(String, unique=True, nullable=False)
-    password = Column(String, nullable=False)
+    password_hash = Column(String, nullable=False)
     role = Column(String, nullable=False)
-    branch_name = Column(String, nullable=True)
+    branch_id = Column(String, ForeignKey("branches.id"), nullable=True)
+    is_active = Column(Boolean, default=True)
 
 class Branch(Base):
     __tablename__ = "branches"
@@ -169,6 +170,17 @@ class Notification(Base):
     message = Column(String, nullable=False)
     is_read = Column(Integer, default=0)
     created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class SessionToken(Base):
+    __tablename__ = "session_tokens"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    token = Column(String, unique=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime, nullable=True)
+    is_active = Column(Boolean, default=True)
 
 # Database dependency
 def get_db():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ psycopg2-binary==2.9.9
 python-dotenv==1.0.0
 pydantic==2.5.0
 python-multipart==0.0.6
+passlib[bcrypt]==1.7.4

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -27,20 +27,24 @@ class LoginOut(BaseModel):
 class UserBase(BaseModel):
     login: str
     role: str
-    branch_name: Optional[str] = None
+    branch_id: Optional[str] = None
+
 
 class UserCreate(UserBase):
     password: str
+
 
 class UserUpdate(BaseModel):
     login: Optional[str] = None
     password: Optional[str] = None
     role: Optional[str] = None
-    branch_name: Optional[str] = None
+    branch_id: Optional[str] = None
+
 
 class User(UserBase):
     id: str
-    
+    is_active: bool = True
+
     model_config = ConfigDict(from_attributes=True)
 
 # Branch schemas


### PR DESCRIPTION
## Summary
- remove jose/JWT and implement DB-backed session token authentication
- seed default admin and categories with hashed passwords
- document jose removal and add passlib requirement

## Testing
- `python -m py_compile database.py main.py schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68b29a75cc548328b61cef4ca0de3b38