### PR TITLE
Refactor backend for minimal dependencies and clean startup

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,12 +3,30 @@
 
 ## Setup
 
-1. Install PostgreSQL
-2. Create database: `warehouse_db`
-3. Update DATABASE_URL in .env file
-4. If you previously installed `jose`, remove it: `pip uninstall -y jose`
-5. Install dependencies: `pip install -r requirements.txt`
-6. Run server: `python main.py`
+1. Install PostgreSQL and create the `clinic_bot` database.
+2. Optionally create a `.env` file with `DATABASE_URL` if you don't want the default
+   `postgresql+psycopg2://postgres:postgres@127.0.0.1:5432/clinic_bot`.
+3. Install Python dependencies: `pip install -r requirements.txt`.
+4. Start the API with Uvicorn:
+
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+### Quick start on Windows (PowerShell)
+
+```powershell
+cd backend
+python -m venv .venv
+\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+
+# set DB url if needed (or create .env with DATABASE_URL=...)
+# $env:DATABASE_URL="postgresql+psycopg2://postgres:postgres@127.0.0.1:5432/clinic_bot"
+
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+# Then login from frontend with: admin / admin
+```
 
 ## API Endpoints
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -6,10 +6,15 @@ from datetime import datetime
 import os
 from dotenv import load_dotenv
 
+# Load environment variables from .env if present
 load_dotenv()
 
 # Database configuration
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:123@localhost:5432/clinic_bot")
+# Use DATABASE_URL from environment or fallback to local Postgres
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+psycopg2://postgres:postgres@127.0.0.1:5432/clinic_bot",
+)
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -174,13 +174,18 @@ def startup_event():
         try:
             ensure_medicines_category_fk()
         except Exception:
-            pass
+            db.rollback()
         try:
             ensure_schema_patches()
         except Exception:
-            pass
+            db.rollback()
     finally:
         db.close()
+
+
+@app.get("/ping")
+def ping():
+    return {"pong": True}
 
 # Auth endpoints
 @app.post("/auth/login", response_model=LoginResponse)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,6 @@
 
-fastapi==0.104.1
-uvicorn==0.24.0
-sqlalchemy==2.0.23
-psycopg2-binary==2.9.9
-python-dotenv==1.0.0
-pydantic==2.5.0
-python-multipart==0.0.6
+fastapi>=0.110
+uvicorn[standard]>=0.24
+SQLAlchemy>=2.0
+psycopg2-binary>=2.9
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- streamline backend dependencies to FastAPI, Uvicorn, SQLAlchemy, psycopg2-binary and dotenv
- load `DATABASE_URL` from environment with Postgres fallback and provide create_tables helper
- seed admin and default categories on startup with safe schema patches, add `/ping` health route
- document setup and Uvicorn run instructions

## Testing
- `python -m py_compile main.py database.py schemas.py`
- `DATABASE_URL=sqlite:///test.db uvicorn main:app --host 127.0.0.1 --port 8001` *(startup logs observed)*
- `curl -s http://127.0.0.1:8001/ping`
- `curl -s -X POST http://127.0.0.1:8001/auth/login -H 'Content-Type: application/json' -d '{"login":"admin","password":"admin"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b4026b6978832891e4e963f8bfa94c